### PR TITLE
Refactor readme.md formatting and content

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,9 +14,8 @@ meta:
 
 # Piper-TTS - Text to Speech
 
-<PluginLogo/>
-
 Piper speech synthesizer (https://github.com/rhasspy/piper)
 
 <EditPageLink/>
+
 


### PR DESCRIPTION
Removing the logo toml fixed the initial issue, however the build still failed later. The only difference between this plugin and any other is the inclusion of `<PluginLogo/>` without having a logo toml. Now in theory this should not have broken anything but that might not be the case.

To debug, removing the anchor to see if everything builds properly. If it does then we have our anwser about the logo toml and logo anchor.