### PR TITLE
Fix formatting in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 ---
 id: piper-tts
-label: Piper-TTS
+label: Piper TTS
 title: Piper-TTS - Text to Speech
 type: ttss
 description: "Piper speech synthesizer"
@@ -17,5 +17,6 @@ meta:
 Piper speech synthesizer (https://github.com/rhasspy/piper)
 
 <EditPageLink/>
+
 
 


### PR DESCRIPTION
I believe I have found the issue, the id is able to have a dash in it, but I think the label can not or it breaks the processing. So in the [https://npeeditor.projectnaomi.com](https://npeeditor.projectnaomi.com), You can type `Piper TTS` and that would be used for the label and then the 'space' will be replaced with a dash for the id which is intended.

Again, thats what appears to be but messing with all of the code and debugging for the first time in years isnt the easiest so I might be off but we will see.